### PR TITLE
Nicer error when HUBOT_GITHUB_REPOS_MAP is not set

### DIFF
--- a/src/github.coffee
+++ b/src/github.coffee
@@ -28,6 +28,8 @@
 
 token = process.env.HUBOT_GITHUB_TOKEN
 githubOrg = process.env.HUBOT_GITHUB_ORG
+if not process.env.HUBOT_GITHUB_REPOS_MAP
+  throw new Error('Please specify a room:repo mapping in HUBOT_GITHUB_REPOS_MAP - e.g.: {"devops-room": "devops-script-repo"}')
 repos = JSON.parse process.env.HUBOT_GITHUB_REPOS_MAP
 debug = process.env.HUBOT_GITHUB_DEBUG
 


### PR DESCRIPTION
Instead of:

```
$ bin/hubot
...
devopsbot> [Wed Oct 21 2015 05:31:56 GMT-0700 (PDT)] ERROR Unable to load /Users/marca/dev/surveymonkey/DevOps/devopsbot/scripts/github:
           SyntaxError: Unexpected token u
  at Object.parse (native)
  at Object.<anonymous> (/Users/marca/dev/surveymonkey/DevOps/devopsbot/scripts/github.coffee:31:27, <js>:8:16)
  at Object.<anonymous> (/Users/marca/dev/surveymonkey/DevOps/devopsbot/scripts/github.coffee:29:1, <js>:266:4)
  at Module._compile (module.js:434:26)
...
```

we get the more friendly:

```
$ bin/hubot
...
devopsbot> [Wed Oct 21 2015 05:39:20 GMT-0700 (PDT)] ERROR Unable to load /Users/marca/dev/surveymonkey/DevOps/devopsbot/scripts/github:
           Error: Please specify a room:repo mapping in HUBOT_GITHUB_REPOS_MAP - e.g.: {"devops-room": "devops-script-repo"}
  at Object.<anonymous> (/Users/marca/dev/surveymonkey/DevOps/devopsbot/scripts/github.coffee:32:13, <js>:9:11)
  at Object.<anonymous> (/Users/marca/dev/surveymonkey/DevOps/devopsbot/scripts/github.coffee:29:1, <js>:270:4)
  at Module._compile (module.js:434:26)
...
```
